### PR TITLE
Provide helper to fetch external embedding demo assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ wandb/
 swanlog/
 generated_predictions.jsonl
 predictions_score.json
+
+# external embedding demo assets
+data/external_embedding_bank_demo.pt
+data/tiny-external-model/

--- a/data/dataset_info.json
+++ b/data/dataset_info.json
@@ -714,5 +714,14 @@
       "prompt": "content"
     },
     "folder": "python"
+  },
+  "external_embedding_demo": {
+    "file_name": "external_embedding_demo.json",
+    "columns": {
+      "prompt": "instruction",
+      "query": "input",
+      "response": "output",
+      "embeddings": "embeddings"
+    }
   }
 }

--- a/data/external_embedding_demo.json
+++ b/data/external_embedding_demo.json
@@ -1,0 +1,20 @@
+[
+  {
+    "instruction": "use retrieved facts from ids demo0 demo1.",
+    "input": "context: solar array stable; battery charged.",
+    "output": "answer: solar array stable and battery charged.",
+    "embeddings": ["demo0", "demo1"]
+  },
+  {
+    "instruction": "use retrieved facts from ids demo2.",
+    "input": "context: gamma status nominal.",
+    "output": "answer: gamma status nominal.",
+    "embeddings": ["demo2"]
+  },
+  {
+    "instruction": "use retrieved facts from ids demo1 demo3 demo0.",
+    "input": "context: delta vectors align model input.",
+    "output": "answer: delta vectors align model input.",
+    "embeddings": ["demo1", "demo3", "demo0"]
+  }
+]

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,19 @@ llamafactory-cli train examples/train_lora/llama3_lora_pretrain.yaml
 llamafactory-cli train examples/train_lora/llama3_lora_sft.yaml
 ```
 
+#### Supervised Fine-Tuning with External Embeddings
+
+This minimal recipe keeps the learnable projector trainable while the base model runs with LoRA adapters. It relies on
+`data/external_embedding_demo.json` containing embedding identifiers and the companion
+`data/external_embedding_bank_demo.pt` library, which stores the 1024-dim vectors keyed by those ids.
+Generate these assets alongside the tiny offline model by running
+`python scripts/prepare_external_embedding_demo.py` once before launching the training
+job.
+
+```bash
+PYTHONPATH=src python -m llamafactory.cli train examples/train_lora/mini_external.yaml
+```
+
 #### Multimodal Supervised Fine-Tuning
 
 ```bash

--- a/examples/train_lora/mini_external.yaml
+++ b/examples/train_lora/mini_external.yaml
@@ -1,0 +1,45 @@
+### model
+model_name_or_path: ./data/tiny-external-model
+trust_remote_code: false
+
+### method
+stage: sft
+do_train: true
+finetuning_type: lora
+lora_rank: 8
+lora_alpha: 16
+lora_target: q_proj,v_proj,k_proj,o_proj
+external_embedding_dim: 1024
+external_embedding_use_bias: true
+external_embedding_position: prefix
+
+### dataset
+dataset_dir: ./data
+dataset: external_embedding_demo
+template: empty
+cutoff_len: 64
+max_samples: 3
+overwrite_cache: true
+preprocessing_num_workers: 1
+embedding_library_path: ./data/external_embedding_bank_demo.pt
+
+### output
+output_dir: output/mini-external
+logging_steps: 1
+save_steps: 100
+save_only_model: true
+report_to: none
+plot_loss: true
+overwrite_output_dir: true
+seed: 42
+
+### train
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 1
+learning_rate: 1.0e-4
+lr_scheduler_type: cosine
+warmup_ratio: 0.1
+max_steps: 10
+bf16: false
+fp16: false
+ddp_timeout: 180000000

--- a/scripts/prepare_external_embedding_demo.py
+++ b/scripts/prepare_external_embedding_demo.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Utilities to fetch the tiny offline model and demo embedding bank used by the
+external embedding integration examples.
+
+The repo avoids shipping binary checkpoints to keep the history lightweight.
+Run this helper to materialize the assets locally before launching
+``examples/train_lora/mini_external.yaml``.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Iterable
+
+MODEL_FILES = (
+    "config.json",
+    "generation_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "model.safetensors",
+)
+
+
+def copy_selected_files(src: Path, dest: Path, filenames: Iterable[str]) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in filenames:
+        src_path = src / name
+        if not src_path.exists():
+            raise FileNotFoundError(
+                f"Required file {name!r} was not present in snapshot {src}."
+            )
+        shutil.copy2(src_path, dest / name)
+
+
+def download_tiny_model(output_dir: Path, repo_id: str, revision: str | None) -> None:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:  # pragma: no cover - convenience guard for optional dep
+        raise SystemExit(
+            "huggingface_hub is required to download the demo checkpoint. Install it "
+            "before rerunning this helper."
+        ) from exc
+
+    snapshot_path = Path(
+        snapshot_download(
+            repo_id=repo_id,
+            revision=revision,
+            allow_patterns=list(MODEL_FILES),
+        )
+    )
+    copy_selected_files(snapshot_path, output_dir, MODEL_FILES)
+
+
+def build_embedding_bank(
+    output_path: Path,
+    dim: int,
+    count: int,
+    prefix: str,
+    seed: int,
+) -> None:
+    try:
+        import torch
+    except ImportError as exc:  # pragma: no cover - convenience guard for optional dep
+        raise SystemExit(
+            "torch is required to author the demo embedding bank. Install it before "
+            "rerunning this helper."
+        ) from exc
+
+    if count <= 0:
+        raise ValueError("Number of demo ids must be positive.")
+    if dim <= 0:
+        raise ValueError("Embedding dimension must be positive.")
+
+    torch.manual_seed(seed)
+    tensors = {
+        f"{prefix}{idx}": torch.randn(dim) for idx in range(count)
+    }
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(tensors, output_path)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model-output",
+        type=Path,
+        default=Path("data/tiny-external-model"),
+        help="Directory where the tiny causal LM checkpoint will be stored.",
+    )
+    parser.add_argument(
+        "--embedding-bank",
+        type=Path,
+        default=Path("data/external_embedding_bank_demo.pt"),
+        help="Path of the generated torch archive containing demo embeddings.",
+    )
+    parser.add_argument(
+        "--embedding-dim",
+        type=int,
+        default=1024,
+        help="Dimensionality for each generated embedding vector.",
+    )
+    parser.add_argument(
+        "--num-ids",
+        type=int,
+        default=4,
+        help="How many demo embedding identifiers to author.",
+    )
+    parser.add_argument(
+        "--id-prefix",
+        type=str,
+        default="demo",
+        help="Prefix used when generating embedding identifiers.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used when sampling demo embeddings.",
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        default="hf-internal-testing/tiny-random-LlamaForCausalLM",
+        help="Model repository that hosts a compact LLaMA-like checkpoint.",
+    )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default=None,
+        help="Optional revision of the model repository to pin.",
+    )
+    parser.add_argument(
+        "--skip-model",
+        action="store_true",
+        help="Only (re)generate the embedding bank without downloading the model.",
+    )
+    parser.add_argument(
+        "--skip-bank",
+        action="store_true",
+        help="Only download the model without touching the embedding bank.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.skip_model:
+        download_tiny_model(args.model_output, args.repo_id, args.revision)
+        print(f"Saved tiny checkpoint to {args.model_output.resolve()}")
+
+    if not args.skip_bank:
+        build_embedding_bank(
+            args.embedding_bank,
+            args.embedding_dim,
+            args.num_ids,
+            args.id_prefix,
+            args.seed,
+        )
+        print(f"Wrote demo embedding bank to {args.embedding_bank.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/llamafactory/data/converter.py
+++ b/src/llamafactory/data/converter.py
@@ -127,6 +127,7 @@ class AlpacaDatasetConverter(DatasetConverter):
             "_images": self._find_medias(example[self.dataset_attr.images]) if self.dataset_attr.images else None,
             "_videos": self._find_medias(example[self.dataset_attr.videos]) if self.dataset_attr.videos else None,
             "_audios": self._find_medias(example[self.dataset_attr.audios]) if self.dataset_attr.audios else None,
+            "_embeddings": example[self.dataset_attr.embeddings] if self.dataset_attr.embeddings else None,
         }
         return output
 
@@ -363,6 +364,7 @@ class OpenAIDatasetConverter(DatasetConverter):
             "_images": self._find_medias(example[self.dataset_attr.images]) if self.dataset_attr.images else None,
             "_videos": self._find_medias(example[self.dataset_attr.videos]) if self.dataset_attr.videos else None,
             "_audios": self._find_medias(example[self.dataset_attr.audios]) if self.dataset_attr.audios else None,
+            "_embeddings": example[self.dataset_attr.embeddings] if self.dataset_attr.embeddings else None,
         }
         return output
 
@@ -406,6 +408,7 @@ def align_dataset(
     _images: []
     _videos: []
     _audios: []
+    _embeddings: []
     """
     column_names = list(next(iter(dataset)).keys())
     kwargs = {}

--- a/src/llamafactory/data/embedding_loader.py
+++ b/src/llamafactory/data/embedding_loader.py
@@ -1,0 +1,84 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import torch
+
+from ..extras import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+class ExternalEmbeddingLibrary:
+    """Load and resolve embeddings stored in a torch serialized dictionary."""
+
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+        if not self.path.exists():
+            raise FileNotFoundError(f"Embedding library file not found: {self.path}")
+
+        raw = torch.load(self.path, map_location="cpu")
+        if not isinstance(raw, dict):
+            raise TypeError("Embedding library must be a dictionary mapping id -> tensor or list.")
+
+        self._embeddings: Dict[str, torch.Tensor] = {}
+        dims: set[int] = set()
+        for key, value in raw.items():
+            tensor = torch.as_tensor(value, dtype=torch.float32)
+            if tensor.dim() != 1:
+                raise ValueError(
+                    "Each embedding must be one-dimensional (representing a single token vector)."
+                )
+
+            embedding_id = str(key)
+            self._embeddings[embedding_id] = tensor.clone().detach()
+            dims.add(tensor.size(0))
+
+        if len(self._embeddings) == 0:
+            raise ValueError("Embedding library is empty.")
+
+        if len(dims) != 1:
+            raise ValueError("Embeddings in the library must all share the same dimensionality.")
+
+        self.embedding_dim = dims.pop()
+        logger.info_rank0(
+            "Loaded %d external embeddings from %s (dim=%d).",
+            len(self._embeddings),
+            self.path,
+            self.embedding_dim,
+        )
+
+    def resolve(self, embedding_id: str) -> torch.Tensor:
+        try:
+            return self._embeddings[embedding_id].clone().detach()
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Embedding id {embedding_id!r} not found in {self.path}.") from exc
+
+    def batch_resolve(self, embedding_ids: Sequence[str]) -> torch.Tensor:
+        if len(embedding_ids) == 0:
+            return torch.zeros((0, self.embedding_dim), dtype=torch.float32)
+
+        resolved: List[torch.Tensor] = [self.resolve(str(idx)) for idx in embedding_ids]
+        return torch.stack(resolved, dim=0)
+
+    def __contains__(self, embedding_id: str) -> bool:
+        return embedding_id in self._embeddings
+
+    def keys(self) -> Iterable[str]:  # pragma: no cover - helper for debugging
+        return self._embeddings.keys()

--- a/src/llamafactory/data/parser.py
+++ b/src/llamafactory/data/parser.py
@@ -43,6 +43,7 @@ class DatasetAttr:
     images: Optional[str] = None
     videos: Optional[str] = None
     audios: Optional[str] = None
+    embeddings: Optional[str] = None
     # dpo columns
     chosen: Optional[str] = None
     rejected: Optional[str] = None
@@ -79,7 +80,7 @@ class DatasetAttr:
 
         if "columns" in attr:
             column_names = ["prompt", "query", "response", "history", "messages", "system", "tools"]
-            column_names += ["images", "videos", "audios", "chosen", "rejected", "kto_tag"]
+            column_names += ["images", "videos", "audios", "embeddings", "chosen", "rejected", "kto_tag"]
             for column_name in column_names:
                 self.set_attr(column_name, attr["columns"])
 

--- a/src/llamafactory/data/processor/feedback.py
+++ b/src/llamafactory/data/processor/feedback.py
@@ -113,6 +113,7 @@ class FeedbackDatasetProcessor(DatasetProcessor):
             model_inputs["images"].append(examples["_images"][i])
             model_inputs["videos"].append(examples["_videos"][i])
             model_inputs["audios"].append(examples["_audios"][i])
+            model_inputs["embeddings"].append(examples["_embeddings"][i])
 
         desirable_num = sum([1 for tag in model_inputs["kto_tags"] if tag])
         undesirable_num = len(model_inputs["kto_tags"]) - desirable_num

--- a/src/llamafactory/data/processor/pairwise.py
+++ b/src/llamafactory/data/processor/pairwise.py
@@ -96,6 +96,7 @@ class PairwiseDatasetProcessor(DatasetProcessor):
             model_inputs["images"].append(examples["_images"][i])
             model_inputs["videos"].append(examples["_videos"][i])
             model_inputs["audios"].append(examples["_audios"][i])
+            model_inputs["embeddings"].append(examples["_embeddings"][i])
 
         return model_inputs
 

--- a/src/llamafactory/data/processor/unsupervised.py
+++ b/src/llamafactory/data/processor/unsupervised.py
@@ -81,6 +81,7 @@ class UnsupervisedDatasetProcessor(DatasetProcessor):
             model_inputs["images"].append(examples["_images"][i])
             model_inputs["videos"].append(examples["_videos"][i])
             model_inputs["audios"].append(examples["_audios"][i])
+            model_inputs["embeddings"].append(examples["_embeddings"][i])
 
         return model_inputs
 

--- a/src/llamafactory/hparams/data_args.py
+++ b/src/llamafactory/hparams/data_args.py
@@ -137,6 +137,16 @@ class DataArguments:
         default=False,
         metadata={"help": "Whether or not to use a shared file system for the datasets."},
     )
+    embedding_library_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Path to a torch serialized dictionary that maps embedding identifiers to vectors. "
+                "When provided, dataset rows can reference external embeddings by id instead of "
+                "embedding the raw vectors in the dataset file."
+            )
+        },
+    )
 
     def __post_init__(self):
         def split_arg(arg):

--- a/src/llamafactory/hparams/model_args.py
+++ b/src/llamafactory/hparams/model_args.py
@@ -75,6 +75,18 @@ class BaseModelArguments:
         default=None,
         metadata={"help": "Special tokens to be added into the tokenizer. Use commas to separate multiple tokens."},
     )
+    external_embedding_dim: Optional[int] = field(
+        default=None,
+        metadata={"help": "Dimension of the external embeddings to be injected into the model."},
+    )
+    external_embedding_use_bias: bool = field(
+        default=True,
+        metadata={"help": "Whether to use a bias term in the external embedding projection layer."},
+    )
+    external_embedding_position: Literal["prefix", "suffix"] = field(
+        default="prefix",
+        metadata={"help": "Where to insert projected external embeddings in the token sequence."},
+    )
     model_revision: str = field(
         default="main",
         metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
@@ -178,6 +190,9 @@ class BaseModelArguments:
 
         if self.split_special_tokens and self.use_fast_tokenizer:
             raise ValueError("`split_special_tokens` is only supported for slow tokenizers.")
+
+        if self.external_embedding_dim is not None and self.external_embedding_dim <= 0:
+            raise ValueError("`external_embedding_dim` must be a positive integer.")
 
         if self.adapter_name_or_path is not None:  # support merging multiple lora weights
             self.adapter_name_or_path = [path.strip() for path in self.adapter_name_or_path.split(",")]

--- a/src/llamafactory/model/adapter.py
+++ b/src/llamafactory/model/adapter.py
@@ -198,6 +198,12 @@ def _setup_lora_tuning(
         logger.info_rank0("Loaded adapter(s): {}".format(",".join(model_args.adapter_name_or_path)))
 
     if is_trainable and adapter_to_resume is None:  # create new lora weights while training
+        if hasattr(model, "external_embedding_projector"):
+            if finetuning_args.additional_target is None:
+                finetuning_args.additional_target = []
+            if "external_embedding_projector" not in finetuning_args.additional_target:
+                finetuning_args.additional_target.append("external_embedding_projector")
+
         if len(finetuning_args.lora_target) == 1 and finetuning_args.lora_target[0] == "all":
             target_modules = find_all_linear_modules(model, finetuning_args.freeze_vision_tower)
         else:

--- a/src/llamafactory/model/model_utils/external_embedding.py
+++ b/src/llamafactory/model/model_utils/external_embedding.py
@@ -1,0 +1,187 @@
+# Copyright 2025 the LlamaFactory team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import MethodType
+from typing import Optional
+
+import torch
+from torch import nn
+
+from ...extras import logging
+
+
+logger = logging.get_logger(__name__)
+
+
+class ExternalEmbeddingProjector(nn.Module):
+    """Project external embeddings to the language model hidden space."""
+
+    def __init__(self, input_dim: int, hidden_size: int, use_bias: bool = True) -> None:
+        super().__init__()
+        self.input_dim = input_dim
+        self.hidden_size = hidden_size
+        self.projection = nn.Linear(input_dim, hidden_size, bias=use_bias)
+
+    def forward(self, embeddings: torch.Tensor) -> torch.Tensor:
+        if embeddings.numel() == 0:
+            return embeddings.new_zeros(embeddings.size(0), embeddings.size(1), self.hidden_size)
+
+        original_shape = embeddings.shape
+        projected = self.projection(embeddings.view(-1, original_shape[-1]))
+        return projected.view(original_shape[0], original_shape[1], self.hidden_size)
+
+
+def _infer_hidden_size(model: "torch.nn.Module") -> int:
+    config = getattr(model, "config", None)
+    if config is None:
+        raise ValueError("Cannot infer hidden size without model config.")
+
+    candidates = [config]
+    if getattr(config, "text_config", None) is not None:
+        candidates.append(config.text_config)
+
+    attr_names = ["hidden_size", "hidden_dim", "n_embd", "d_model", "model_dim", "dim"]
+    for candidate in candidates:
+        for attr in attr_names:
+            value = getattr(candidate, attr, None)
+            if isinstance(value, int) and value > 0:
+                return value
+
+    raise ValueError("Cannot infer model hidden size for external embedding projector.")
+
+
+def _get_weight_dtype(model: "torch.nn.Module") -> torch.dtype:
+    embedding = getattr(model, "get_input_embeddings", None)
+    if callable(embedding):
+        weight = embedding().weight
+        if weight is not None:
+            return weight.dtype
+
+    try:
+        parameter = next(model.parameters())
+        return parameter.dtype
+    except StopIteration:  # pragma: no cover - safeguard
+        return torch.get_default_dtype()
+
+
+def attach_external_embedding_module(
+    model: "torch.nn.Module",
+    external_dim: Optional[int],
+    use_bias: bool,
+    position: str,
+) -> Optional[ExternalEmbeddingProjector]:
+    """Attach the projection module and patch forward for external embeddings."""
+
+    if external_dim is None:
+        return None
+
+    if external_dim <= 0:
+        raise ValueError("`external_embedding_dim` must be a positive integer.")
+
+    if hasattr(model, "external_embedding_projector"):
+        projector = getattr(model, "external_embedding_projector")
+        if not isinstance(projector, ExternalEmbeddingProjector):
+            raise TypeError("`external_embedding_projector` already exists with an unsupported type.")
+
+        if projector.input_dim != external_dim or projector.hidden_size != _infer_hidden_size(model):
+            logger.warning_rank0("Reinitializing external embedding projector due to configuration changes.")
+            projector = ExternalEmbeddingProjector(external_dim, _infer_hidden_size(model), use_bias)
+            setattr(model, "external_embedding_projector", projector)
+    else:
+        projector = ExternalEmbeddingProjector(external_dim, _infer_hidden_size(model), use_bias)
+        setattr(model, "external_embedding_projector", projector)
+
+    try:
+        first_param = next(model.parameters())
+    except StopIteration:  # pragma: no cover - safeguard for empty modules
+        first_param = None
+
+    device = first_param.device if first_param is not None else torch.device("cpu")
+    projector.to(device=device, dtype=_get_weight_dtype(model))
+
+    config = getattr(model, "config", None)
+    if config is not None:
+        setattr(config, "external_embedding_dim", external_dim)
+        setattr(config, "external_embedding_use_bias", use_bias)
+        setattr(config, "external_embedding_position", position)
+
+    _patch_model_forward(model)
+    return projector
+
+
+def _patch_model_forward(model: "torch.nn.Module") -> None:
+    if getattr(model, "_external_embedding_forward_patched", False):
+        return
+
+    raw_forward = model.forward
+
+    def forward(
+        self,
+        *args,
+        external_embeddings: Optional[torch.Tensor] = None,
+        external_attention_mask: Optional[torch.Tensor] = None,
+        external_token_count: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        if external_embeddings is not None and external_attention_mask is not None:
+            projector: ExternalEmbeddingProjector = getattr(self, "external_embedding_projector")
+            if projector is None:
+                raise ValueError("External embeddings are provided but the projector is missing.")
+
+            input_ids = kwargs.get("input_ids")
+            inputs_embeds = kwargs.get("inputs_embeds")
+
+            if inputs_embeds is None:
+                if input_ids is None:
+                    raise ValueError("Either `input_ids` or `inputs_embeds` must be provided.")
+
+                embed_layer = self.get_input_embeddings()
+                inputs_embeds = embed_layer(input_ids)
+                kwargs["input_ids"] = None
+
+            # Avoid in-place modifications on a view that would break autograd.
+            inputs_embeds = inputs_embeds.clone()
+            kwargs["inputs_embeds"] = inputs_embeds
+
+            counts = (
+                external_token_count.to(inputs_embeds.device)
+                if external_token_count is not None
+                else external_attention_mask.sum(dim=-1).to(inputs_embeds.device)
+            )
+
+            max_tokens = external_embeddings.size(1)
+            if max_tokens > 0:
+                projected = projector(external_embeddings.to(inputs_embeds.device))
+                projected = projected.to(inputs_embeds.dtype)
+
+                prefix = inputs_embeds[:, :max_tokens, :]
+                if prefix.size(1) < max_tokens:
+                    raise ValueError("Input ids must reserve placeholder positions for external embeddings.")
+
+                mask = (
+                    torch.arange(max_tokens, device=prefix.device).unsqueeze(0) < counts.unsqueeze(1)
+                ).unsqueeze(-1)
+                updated_prefix = torch.where(mask, projected, prefix)
+                inputs_embeds = torch.cat((updated_prefix, inputs_embeds[:, max_tokens:, :]), dim=1)
+                kwargs["inputs_embeds"] = inputs_embeds
+
+        kwargs.pop("external_embeddings", None)
+        kwargs.pop("external_attention_mask", None)
+        kwargs.pop("external_token_count", None)
+
+        return raw_forward(*args, **kwargs)
+
+    model.forward = MethodType(forward, model)
+    setattr(model, "_external_embedding_forward_patched", True)
+

--- a/src/llamafactory/train/dpo/workflow.py
+++ b/src/llamafactory/train/dpo/workflow.py
@@ -51,6 +51,7 @@ def run_dpo(
         model=model,
         pad_to_multiple_of=8,
         label_pad_token_id=IGNORE_INDEX if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id,
+        embedding_library_path=data_args.embedding_library_path,
         **tokenizer_module,
     )
 

--- a/src/llamafactory/train/kto/trainer.py
+++ b/src/llamafactory/train/kto/trainer.py
@@ -161,6 +161,11 @@ class CustomKTOTrainer(KTOTrainer):
         if f"{prefix}cross_attention_mask" in batch:
             model_inputs["cross_attention_mask"] = batch[f"{prefix}cross_attention_mask"]
 
+        if f"{prefix}external_embeddings" in batch:
+            model_inputs["external_embeddings"] = batch[f"{prefix}external_embeddings"]
+            model_inputs["external_attention_mask"] = batch[f"{prefix}external_attention_mask"]
+            model_inputs["external_token_count"] = batch[f"{prefix}external_token_count"]
+
         logits = model(**model_inputs, return_dict=True, use_cache=False).logits.to(torch.float32)
         logps, valid_length = get_batch_logps(logits=logits, labels=batch[f"{prefix}labels"])
         return logits, logps, logps / valid_length

--- a/src/llamafactory/train/kto/workflow.py
+++ b/src/llamafactory/train/kto/workflow.py
@@ -50,6 +50,7 @@ def run_kto(
         model=model,
         pad_to_multiple_of=8,
         label_pad_token_id=IGNORE_INDEX if data_args.ignore_pad_token_for_loss else tokenizer.pad_token_id,
+        embedding_library_path=data_args.embedding_library_path,
         **tokenizer_module,
     )
 

--- a/src/llamafactory/train/ppo/workflow.py
+++ b/src/llamafactory/train/ppo/workflow.py
@@ -46,7 +46,12 @@ def run_ppo(
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train, add_valuehead=True)
 
     tokenizer.padding_side = "left"  # use left-padding in generation while using right-padding in training
-    data_collator = MultiModalDataCollatorForSeq2Seq(template=template, model=model, **tokenizer_module)
+    data_collator = MultiModalDataCollatorForSeq2Seq(
+        template=template,
+        model=model,
+        embedding_library_path=data_args.embedding_library_path,
+        **tokenizer_module,
+    )
 
     # Create reference model and reward model
     ref_model = create_ref_model(model_args, finetuning_args, add_valuehead=True)

--- a/src/llamafactory/train/rm/workflow.py
+++ b/src/llamafactory/train/rm/workflow.py
@@ -45,7 +45,11 @@ def run_rm(
     dataset_module = get_dataset(template, model_args, data_args, training_args, stage="rm", **tokenizer_module)
     model = load_model(tokenizer, model_args, finetuning_args, training_args.do_train, add_valuehead=True)
     data_collator = PairwiseDataCollatorWithPadding(
-        template=template, model=model, pad_to_multiple_of=8, **tokenizer_module
+        template=template,
+        model=model,
+        pad_to_multiple_of=8,
+        embedding_library_path=data_args.embedding_library_path,
+        **tokenizer_module,
     )
 
     # Initialize our Trainer

--- a/src/llamafactory/train/sft/workflow.py
+++ b/src/llamafactory/train/sft/workflow.py
@@ -62,6 +62,7 @@ def run_sft(
         block_diag_attn=model_args.block_diag_attn,
         attn_implementation=getattr(model.config, "_attn_implementation", None),
         compute_dtype=model_args.compute_dtype,
+        embedding_library_path=data_args.embedding_library_path,
         **tokenizer_module,
     )
 


### PR DESCRIPTION
## Summary
- replace the committed demo checkpoint and embedding bank with the `prepare_external_embedding_demo.py` utility that downloads the tiny HF model and samples demo vectors on demand
- document running the helper in the data guide and external embedding example so the training recipe works without shipping binaries
- ignore the generated assets so future runs keep the repository history free of large binary blobs

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c907d9aaf88328a07fde4d28d46945